### PR TITLE
Update import path for DButtonTooltip component

### DIFF
--- a/javascripts/discourse/connectors/before-create-topic-button/compose-center.gjs
+++ b/javascripts/discourse/connectors/before-create-topic-button/compose-center.gjs
@@ -12,7 +12,7 @@ import DiscourseURL from "discourse/lib/url";
 import { optionalRequire } from "discourse/lib/utilities";
 import DMenu from "float-kit/components/d-menu";
 import DButton from "discourse/components/d-button";
-import DButtonTooltip from "discourse/components/d-button-tooltip";
+import DButtonTooltip from "discourse/float-kit/components/d-button-tooltip";
 import DTooltip from "float-kit/components/d-tooltip";
 import Category from "discourse/models/category";
 import emoji from "discourse/helpers/emoji";


### PR DESCRIPTION
fixes the error in the path to the `d-button-tooltip` component

<img width="1040" height="84" alt="Screenshot 2025-11-14 at 1 03 40 PM" src="https://github.com/user-attachments/assets/f01f1ed9-dba2-4631-8b18-3c8efe8138a6" />



`import DButtonTooltip from "discourse/float-kit/components/d-button-tooltip";`
